### PR TITLE
FEATURE: Allow EmailFinisher template source to be set

### DIFF
--- a/Configuration/NodeTypes.Finishers.Email.yaml
+++ b/Configuration/NodeTypes.Finishers.Email.yaml
@@ -23,6 +23,15 @@
             requried: true
       validation:
         'Neos.Neos/Validation/NotEmptyValidator': []
+    'templateSource':
+      type: string
+      ui:
+        label: i18n
+        inspector:
+          group: 'finisher'
+          editor: 'Neos.Neos/Inspector/Editors/CodeEditor'
+          editorOptions:
+            buttonLabel: i18n
     'recipientAddress':
       type: string
       ui:

--- a/Resources/Private/Translations/en/NodeTypes/EmailFinisher.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/EmailFinisher.xlf
@@ -11,6 +11,12 @@
 			<trans-unit id="properties.subject" xml:space="preserve">
 				<source>Email subject</source>
 			</trans-unit>
+			<trans-unit id="properties.templateSource" xml:space="preserve">
+				<source>Email body (Fluid)</source>
+			</trans-unit>
+			<trans-unit id="properties.templateSource.codeEditor.buttonLabel" xml:space="preserve">
+				<source>Edit Email body</source>
+			</trans-unit>
 			<trans-unit id="properties.recipientAddress" xml:space="preserve">
 				<source>Recipient email address</source>
 			</trans-unit>


### PR DESCRIPTION
Adds a new property `templateSource` to the `EmailFinisher`
node type that allows for setting the email body in the Neos backend.