### PR TITLE
WIP: FEATURE: Custom "creation dialog" for SelectOption nodes

### DIFF
--- a/Classes/NodeType/SelectOptionsCreationHandler.php
+++ b/Classes/NodeType/SelectOptionsCreationHandler.php
@@ -1,0 +1,26 @@
+<?php
+namespace Neos\Form\Builder\NodeType;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
+
+class SelectOptionsCreationHandler implements NodeCreationHandlerInterface
+{
+    /**
+     * @param NodeInterface $node The newly created node
+     * @param array $data incoming data from the creationDialog
+     * @return void
+     */
+    public function handle(NodeInterface $node, array $data)
+    {
+        if (!$node->getNodeType()->isOfType('Neos.Form.Builder:SelectOption')) {
+            return;
+        }
+        if (isset($data['value'])) {
+            $node->setProperty('value', $data['value']);
+        }
+        if (isset($data['label'])) {
+            $node->setProperty('label', $data['label']);
+        }
+    }
+}

--- a/Configuration/NodeTypes.FormElement.yaml
+++ b/Configuration/NodeTypes.FormElement.yaml
@@ -68,7 +68,24 @@
           label: i18n
           position: 45
           icon: 'icon-stop-circle-o'
+    creationDialog:
+      elements:
+        'value':
+          type: string
+          ui:
+            label: 'Value'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
+          validation:
+            'Neos.Neos/Validation/NotEmptyValidator': []
+        'label':
+          type: string
+          ui:
+            label: 'Label (optional)'
+            editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
   options:
+    nodeCreationHandlers:
+      documentTitle:
+        nodeCreationHandler: 'Neos\Form\Builder\NodeType\SelectOptionsCreationHandler'
     fusion:
       prototypeGenerator: null
   properties:


### PR DESCRIPTION
This change adds configuration for a "creation dialog" (requires the
react based Neos UI) in order to prevent empty `SelectOption`
nodes from being created.

Related: #7