### PR TITLE
BUGFIX: Add site to caching context

### DIFF
--- a/Resources/Private/Fusion/NodeBased/NodeBasedForm.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedForm.fusion
@@ -29,6 +29,7 @@ prototype(Neos.Form.Builder:NodeBasedForm) < prototype(Neos.Form.Builder:Form) {
         context {
             1 = 'node'
             2 = 'documentNode'
+            3 = 'site'
         }
     }
 }


### PR DESCRIPTION
Adds `site` to the `@cache` context configuration of
the `Neos.Form.Builder:NodeBasedForm` fusion prototype
in order to allow site-specific queries within custom
form elements.

Related: #7