### PR TITLE
TASK: Default Value for SelectOptions

### DIFF
--- a/Configuration/NodeTypes.FormElement.yaml
+++ b/Configuration/NodeTypes.FormElement.yaml
@@ -74,6 +74,7 @@
   properties:
     'value':
       type: string
+      defaultValue: 'value'
       ui:
         label: i18n
         reloadIfChanged: TRUE


### PR DESCRIPTION
This adds a default value to the `value` property of the
`Neos.Form.Builder:SelectOption` NodeType definition.

Background:

Without the default value, rendering might be broken until
a value is specified.

Related: #7 
Related: #8