### PR TITLE
FEATURE: Better support for custom select elements

### DIFF
--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
@@ -12,14 +12,14 @@ prototype(Neos.Form.Builder:NodeBasedFormElement) < prototype(Neos.Fusion:Render
         renderingOptions._node = ${elementNode}
         renderingOptions._fusionPath = ${element.path}
 
-        properties.options {
+        properties.options.@process.overrideFromNode = Neos.Form.Builder:SelectOptionCollection {
             collection = ${q(elementNode).children('options').children()}
             valuePropertyPath = 'properties.value'
             labelPropertyPath = 'properties.label'
             @if.isSelectFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SelectionMixin]')}
         }
 
-        elements = Neos.Form.Builder:NodeBasedElementCollection {
+        elements.@process.overrideFromNode = Neos.Form.Builder:NodeBasedElementCollection {
             collection = ${q(elementNode).children('elements').children()}
             @if.isSectionFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SectionMixin]')}
         }


### PR DESCRIPTION
Adjusts the `Neos.Form.Builder:NodeBasedFormElement` Fusion prototype
slightly to use processors for `properties.options` and `elements` in
order to make it easier to manipulate those in custom implementations.

This also adds documentation on how to create custom select elements.

Background:

When using `@if` alone on a property, its value will be `null` if the
condition doesn't match - even if the property has a value in the
extended prototype.

Related: #7 
Related: #8