### PR TITLE
BUGFIX: Allow `NodeBasedFormElement`s to be overridden

### DIFF
--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
@@ -12,15 +12,19 @@ prototype(Neos.Form.Builder:NodeBasedFormElement) < prototype(Neos.Fusion:Render
         renderingOptions._node = ${elementNode}
         renderingOptions._fusionPath = ${element.path}
 
-        properties.options {
-            collection = ${q(elementNode).children('options').children()}
-            valuePropertyPath = 'properties.value'
-            labelPropertyPath = 'properties.label'
+        properties.options.@process.addOptionsFromNodes {
+            expression = Neos.Form.Builder:SelectOptionCollection {
+                collection = ${q(elementNode).children('options').children()}
+                valuePropertyPath = 'properties.value'
+                labelPropertyPath = 'properties.label'
+            }
             @if.isSelectFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SelectionMixin]')}
         }
 
-        elements = Neos.Form.Builder:NodeBasedElementCollection {
-            collection = ${q(elementNode).children('elements').children()}
+        elements.@process.addElementsFromNodes {
+            expression = Neos.Form.Builder:NodeBasedElementCollection {
+                collection = ${q(elementNode).children('elements').children()}
+            }
             @if.isSectionFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SectionMixin]')}
         }
     }


### PR DESCRIPTION
The `properties.options` of a form element were overridden
by the `NodeBasedFormElement` prototype if the node implemented
the `Neos.Form.Builder:SelectionMixin`.
Otherwise the `@if` condition led to an *empty* array even
if it was filled in the concrete implementation.

By replacing the implementation with a `@process` expression
the value is untouched if the condition is not satisfied, allowing
custom implementations to override the value.

This also fixes the same issue for the `elements` option of
`SectionMixin` nodes.

Fixes: #18