### PR TITLE
BUGFIX: Throw exception for missing context variables

### DIFF
--- a/Classes/Fusion/FinisherImplementation.php
+++ b/Classes/Fusion/FinisherImplementation.php
@@ -11,6 +11,9 @@ class FinisherImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->runtime->getCurrentContext();
+        if (!isset($context['form'])) {
+            throw new FusionException(sprintf('Missing "form" in context for Finisher Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522829109);
+        }
         // TODO error handling if "form" is not available
         /** @var FormDefinition $formDefinition */
         $formDefinition = $context['form'];

--- a/Classes/Fusion/FormElementImplementation.php
+++ b/Classes/Fusion/FormElementImplementation.php
@@ -18,7 +18,9 @@ class FormElementImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->runtime->getCurrentContext();
-        // TODO error handling if "parentRenderable" is not available
+        if (!isset($context['parentRenderable'])) {
+            throw new FusionException(sprintf('Missing "parentRenderable" in context for Form Element Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522828967);
+        }
         /** @var Page $renderable */
         $renderable = $context['parentRenderable'];
 

--- a/Classes/Fusion/FormElementWrappingImplementation.php
+++ b/Classes/Fusion/FormElementWrappingImplementation.php
@@ -7,6 +7,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Form\Core\Model\Page;
 use Neos\Form\Core\Model\Renderable\RootRenderableInterface;
 use Neos\Form\Core\Runtime\FormRuntime;
+use Neos\Fusion\Exception as FusionException;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Neos\Neos\Service\ContentElementWrappingService;
 
@@ -30,7 +31,9 @@ class FormElementWrappingImplementation extends AbstractFusionObject
     {
         $context = $this->runtime->getCurrentContext();
 
-        // TODO error handling if "formRuntime" is not available
+        if (!isset($context['formRuntime'])) {
+            throw new FusionException(sprintf('Missing "formRuntime" in context for Form Element Wrapping Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522829151);
+        }
         /** @var FormRuntime $formRuntime */
         $formRuntime = $context['formRuntime'];
         $formRuntime->registerRenderCallback(function (string $output, RootRenderableInterface $renderable) {

--- a/Classes/Fusion/FormPageImplementation.php
+++ b/Classes/Fusion/FormPageImplementation.php
@@ -17,9 +17,8 @@ class FormPageImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->runtime->getCurrentContext();
-        // TODO error handling if "form" is not available
         if (!isset($context['form'])) {
-            return '';
+            throw new FusionException(sprintf('Missing "form" in context for Form Page Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522829233);
         }
         /** @var FormDefinition $formDefinition */
         $formDefinition = $context['form'];

--- a/Classes/Fusion/SectionImplementation.php
+++ b/Classes/Fusion/SectionImplementation.php
@@ -18,7 +18,9 @@ class SectionImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->runtime->getCurrentContext();
-        // TODO error handling if "parentRenderable" is not available
+        if (!isset($context['parentRenderable'])) {
+            throw new FusionException(sprintf('Missing "parentRenderable" in context for Section Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522829260);
+        }
         /** @var Page $renderable */
         $renderable = $context['parentRenderable'];
 

--- a/Classes/Fusion/ValidatorImplementation.php
+++ b/Classes/Fusion/ValidatorImplementation.php
@@ -10,7 +10,9 @@ class ValidatorImplementation extends AbstractFusionObject
     public function evaluate()
     {
         $context = $this->runtime->getCurrentContext();
-        // TODO error handling if "element" is not available
+        if (!isset($context['element'])) {
+            throw new FusionException(sprintf('Missing "element" in context for Validator Fusion object "%s" at "%s"', $this->fusionObjectName, $this->path), 1522829281);
+        }
         /** @var AbstractRenderable $element */
         $element = $context['element'];
 


### PR DESCRIPTION
When rendering forms or form elements "out of band" some
variables might be missing from the fusion context.

This adjusts the fusion implementations to throw exceptions
in these cases. Previously they lead to a PHP notice.

Related: #21