### PR TITLE
BUGFIX: Remove minimum option from StringLengthValidators

### DIFF
--- a/Configuration/NodeTypes.Form.yaml
+++ b/Configuration/NodeTypes.Form.yaml
@@ -60,7 +60,6 @@
           group: 'form'
       validation:
         'Neos.Neos/Validation/StringLengthValidator':
-          minimum: 1
           maximum: 255
         'Neos.Neos/Validation/RegularExpressionValidator':
           regularExpression: '/^[a-z0-9\-]+$/i'

--- a/Configuration/NodeTypes.FormElement.Mixins.yaml
+++ b/Configuration/NodeTypes.FormElement.Mixins.yaml
@@ -9,7 +9,6 @@
           group: 'formElement'
       validation:
         'Neos.Neos/Validation/StringLengthValidator':
-          minimum: 1
           maximum: 255
         'Neos.Neos/Validation/RegularExpressionValidator':
           regularExpression: '/^[a-z0-9\-]+$/i'

--- a/Configuration/NodeTypes.FormPage.yaml
+++ b/Configuration/NodeTypes.FormPage.yaml
@@ -31,7 +31,6 @@
           group: 'formPage'
       validation:
         'Neos.Neos/Validation/StringLengthValidator':
-          minimum: 1
           maximum: 255
         'Neos.Neos/Validation/RegularExpressionValidator':
           regularExpression: '/^[a-z0-9\-]+$/i'


### PR DESCRIPTION
This removes the redundant `minimum` option from the
`StringLengthValidador` configuration for the optional `Form`, `Page`
and `FormElement` identifiers in order to prevent validation errors
for omitted values.

Fixes: #35