### PR TITLE
BUGFIX: Revert compatibility with Neos 5.0 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Flow Form Framework integration into Neos CMS",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "^3.1 || ^4.0 || ^5.0",
-        "neos/form": "^4.1 || ^5.0"
+        "neos/neos": "^3.1 || ^4.0",
+        "neos/form": "^4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As we need to change the HTTP component, the package
cannot be compatible with Neos versions 4 and 5.