### PR TITLE
BUGFIX: set unique form element identifier after node copy

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -12,7 +12,7 @@ use Neos\Flow\Package\Package as BasePackage;
  */
 class Package extends BasePackage
 {
-    const NODE_TYPE_IDENTIFIER_MIXIN = 'Neos.Form.Builder:IdentifierMixin';
+    private const NODE_TYPE_IDENTIFIER_MIXIN = 'Neos.Form.Builder:IdentifierMixin';
 
     /**
      * @param Bootstrap $bootstrap The current bootstrap

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -22,7 +22,7 @@ class Package extends BasePackage
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
-        $dispatcher->connect(Node::class, 'nodePropertyChanged', function (NodeInterface $node, $propertyName, $_, $newValue) use ($bootstrap) {
+        $dispatcher->connect(Node::class, 'nodePropertyChanged', function (NodeInterface $node, $propertyName, $_, $newValue) {
             if ($propertyName !== 'identifier' || empty($newValue) || !$node->getNodeType()->isOfType(self::NODE_TYPE_IDENTIFIER_MIXIN)) {
                 return;
             }
@@ -30,7 +30,7 @@ class Package extends BasePackage
             $this->setUniqueFormElementIdentifier($node, $newValue);
         });
 
-        $dispatcher->connect(Node::class, 'nodeAdded', function (NodeInterface $node) use ($bootstrap) {
+        $dispatcher->connect(Node::class, 'nodeAdded', function (NodeInterface $node) {
             try {
                 $identifier = $node->getProperty('identifier');
 
@@ -50,7 +50,7 @@ class Package extends BasePackage
      * @param string $identifier
      * @throws \Neos\Eel\Exception
      */
-    protected function setUniqueFormElementIdentifier(NodeInterface $node, string $identifier): void
+    private function setUniqueFormElementIdentifier(NodeInterface $node, string $identifier): void
     {
         /** @noinspection PhpUndefinedMethodInspection */
         $flowQuery = (new FlowQuery([$node]))->context([

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -30,18 +30,18 @@ class Package extends BasePackage
             $this->setUniqueFormElementIdentifier($node, $newValue);
         });
 
-        $dispatcher->connect(Node::class, 'afterNodeCopy', function (NodeInterface $copiedNode, NodeInterface $targetParentNode) use ($bootstrap) {
+        $dispatcher->connect(Node::class, 'nodeAdded', function (NodeInterface $node) use ($bootstrap) {
             try {
-                $identifier = $copiedNode->getProperty('identifier');
+                $identifier = $node->getProperty('identifier');
 
-                if (empty($identifier) || !$copiedNode->getNodeType()->isOfType(self::NODE_TYPE_IDENTIFIER_MIXIN)) {
+                if (empty($identifier) || !$node->getNodeType()->isOfType(self::NODE_TYPE_IDENTIFIER_MIXIN)) {
                     return;
                 }
             } catch (\Neos\ContentRepository\Exception\NodeException $e) {
                 return;
             }
 
-            $this->setUniqueFormElementIdentifier($copiedNode, $identifier);
+            $this->setUniqueFormElementIdentifier($node, $identifier);
         });
     }
 

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -12,6 +12,8 @@ use Neos\Flow\Package\Package as BasePackage;
  */
 class Package extends BasePackage
 {
+    const NODE_TYPE_IDENTIFIER_MIXIN = 'Neos.Form.Builder:IdentifierMixin';
+
     /**
      * @param Bootstrap $bootstrap The current bootstrap
      * @return void
@@ -21,23 +23,52 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
         $dispatcher->connect(Node::class, 'nodePropertyChanged', function (NodeInterface $node, $propertyName, $_, $newValue) use ($bootstrap) {
-            if ($propertyName !== 'identifier' || empty($newValue) || !$node->getNodeType()->isOfType('Neos.Form.Builder:IdentifierMixin')) {
+            if ($propertyName !== 'identifier' || empty($newValue) || !$node->getNodeType()->isOfType(self::NODE_TYPE_IDENTIFIER_MIXIN)) {
                 return;
             }
 
-            /** @noinspection PhpUndefinedMethodInspection */
-            $flowQuery = (new FlowQuery([$node]))->context(['invisibleContentShown' => true, 'removedContentShown' => true, 'inaccessibleContentShown' => true]);
-            $possibleIdentifier = $initialIdentifier = $newValue;
-            $i = 1;
-            /** @noinspection PhpUndefinedMethodInspection */
-            while ($flowQuery
-                    ->closest('[instanceof Neos.Form.Builder:NodeBasedForm]')
-                    // [identifier=".."] matches the Form Element identifier, [_identiier!="..."] excludes the current node
-                    ->find(sprintf('[instanceof Neos.Form.Builder:IdentifierMixin][identifier="%s"][_identifier!="%s"]', $possibleIdentifier, $node->getIdentifier()))
-                    ->count() > 0) {
-                $possibleIdentifier = $initialIdentifier . '-' . $i++;
-            }
-            $node->setProperty('identifier', $possibleIdentifier);
+            $this->setUniqueFormElementIdentifier($node, $newValue);
         });
+
+        $dispatcher->connect(Node::class, 'afterNodeCopy', function (NodeInterface $copiedNode, NodeInterface $targetParentNode) use ($bootstrap) {
+            try {
+                $identifier = $copiedNode->getProperty('identifier');
+
+                if (empty($identifier) || !$copiedNode->getNodeType()->isOfType(self::NODE_TYPE_IDENTIFIER_MIXIN)) {
+                    return;
+                }
+            } catch (\Neos\ContentRepository\Exception\NodeException $e) {
+                return;
+            }
+
+            $this->setUniqueFormElementIdentifier($copiedNode, $identifier);
+        });
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @param string $identifier
+     * @throws \Neos\Eel\Exception
+     */
+    protected function setUniqueFormElementIdentifier(NodeInterface $node, string $identifier): void
+    {
+        /** @noinspection PhpUndefinedMethodInspection */
+        $flowQuery = (new FlowQuery([$node]))->context([
+            'invisibleContentShown' => true,
+            'removedContentShown' => true,
+            'inaccessibleContentShown' => true
+        ]);
+        $possibleIdentifier = $identifier;
+        $i = 1;
+        /** @noinspection PhpUndefinedMethodInspection */
+        while ($flowQuery
+                ->closest('[instanceof Neos.Form.Builder:NodeBasedForm]')
+                // [identifier=".."] matches the Form Element identifier, [_identiier!="..."] excludes the current node
+                ->find(sprintf('[instanceof %s][identifier="%s"][_identifier!="%s"]',
+                    self::NODE_TYPE_IDENTIFIER_MIXIN ,$possibleIdentifier, $node->getIdentifier()))
+                ->count() > 0) {
+            $possibleIdentifier = $identifier . '-' . $i++;
+        }
+        $node->setProperty('identifier', $possibleIdentifier);
     }
 }


### PR DESCRIPTION
When a form element with identifier propery is copied an exception is thrown.
@see https://github.com/neos/form/blob/3a6122db36ad2c9e6f06316653a35c80ff47dee1/Classes/Core/Model/FormDefinition.php#L553

This changes adds a signal slot for \Neos\ContentRepository\Domain\Model\Node 
~`afterNodeCopy`~ `addedNode` to make the form element identifier unique. This also works if a whole section having a form element with identifier is copied and inserted.

Fixes #44 