### PR TITLE
FEATURE: Set page label from label property

### DIFF
--- a/Configuration/NodeTypes.FormPage.yaml
+++ b/Configuration/NodeTypes.FormPage.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:FormPage':
+  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('label') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' '))), 100, '...')}"
   superTypes:
     'Neos.Neos:Content': true
   constraints:


### PR DESCRIPTION
This way the page will show with its label instead of `Page` in the content tree.