### PR TITLE
Adding two properties autocapitalize and inputmode to be used in input and textarea form elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Configuration/NodeTypes.FormElements.MultiLineText.yaml
+++ b/Configuration/NodeTypes.FormElements.MultiLineText.yaml
@@ -3,6 +3,7 @@
     'Neos.Form.Builder:FormElement': true
     'Neos.Form.Builder:PlaceholderMixin': true
     'Neos.Form.Builder:MaxlengthMixin': true
+    'Neos.Form.Builder:AutoCapitalizeMixin': true
   ui:
     label: 'Multi-line text'
     icon: 'icon-pencil-square-o'

--- a/Configuration/NodeTypes.FormElements.SingleLineText.yaml
+++ b/Configuration/NodeTypes.FormElements.SingleLineText.yaml
@@ -4,6 +4,8 @@
     'Neos.Form.Builder:TextValidatorsMixin': true
     'Neos.Form.Builder:PlaceholderMixin': true
     'Neos.Form.Builder:MaxlengthMixin': true
+    'Neos.Form.Builder:AutoCapitalizeMixin': true
+    'Neos.Form.Builder:InputModeMixin': true
   ui:
     label: 'Single-line text'
     icon: 'icon-pencil-square-o'

--- a/Configuration/NodeTypes.Mixin.AutoCapitalize.yaml
+++ b/Configuration/NodeTypes.Mixin.AutoCapitalize.yaml
@@ -1,0 +1,22 @@
+'Neos.Form.Builder:AutoCapitalizeMixin':
+  ui:
+    position: end
+  properties:
+    'autoCapitalize':
+      type: string
+      defaultValue: 'sentences'
+      ui:
+        label: i18n
+        inspector:
+          group: 'formElement'
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            values:
+              off:
+                label: i18n
+              characters:
+                label: i18n
+              words:
+                label: i18n
+              sentences:
+                label: i18n

--- a/Configuration/NodeTypes.Mixin.InputMode.yaml
+++ b/Configuration/NodeTypes.Mixin.InputMode.yaml
@@ -1,0 +1,30 @@
+'Neos.Form.Builder:InputModeMixin':
+  ui:
+    position: end
+  properties:
+    'inputMode':
+      type: string
+      defaultValue: 'text'
+      ui:
+        label: i18n
+        inspector:
+          group: 'formElement'
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            values:
+              text:
+                label: i18n
+              decimal:
+                label: i18n
+              numeric:
+                label: i18n
+              tel:
+                label: i18n
+              search:
+                label: i18n
+              email:
+                label: i18n
+              url:
+                label: i18n
+              none:
+                label: i18n

--- a/Resources/Private/Translations/en/NodeTypes/AutoCapitalizeMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/AutoCapitalizeMixin.xlf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.autoCapitalize" xml:space="preserve">
+				<source>Auto capitalize</source>
+			</trans-unit>
+			<trans-unit id="properties.autoCapitalize.selectBoxEditor.values.off" xml:space="preserve">
+				<source>Off</source>
+			</trans-unit>
+			<trans-unit id="properties.autoCapitalize.selectBoxEditor.values.characters" xml:space="preserve">
+				<source>Characters</source>
+			</trans-unit>
+			<trans-unit id="properties.autoCapitalize.selectBoxEditor.values.words" xml:space="preserve">
+				<source>Words</source>
+			</trans-unit>
+			<trans-unit id="properties.autoCapitalize.selectBoxEditor.values.sentences" xml:space="preserve">
+				<source>Sentences</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/InputModeMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/InputModeMixin.xlf
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.inputMode" xml:space="preserve">
+				<source>Input mode (relevant for mobile browsers)</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.decimal" xml:space="preserve">
+				<source>Decimal</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.email" xml:space="preserve">
+				<source>Email</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.none" xml:space="preserve">
+				<source>None</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.numeric" xml:space="preserve">
+				<source>Numeric</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.search" xml:space="preserve">
+				<source>Search</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.tel" xml:space="preserve">
+				<source>Telephone</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.text" xml:space="preserve">
+				<source>Text</source>
+			</trans-unit>
+			<trans-unit id="properties.inputMode.selectBoxEditor.values.url" xml:space="preserve">
+				<source>URL</source>
+			</trans-unit>
+
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
Add two mixins for "autocapitalize" and "inputmode" which can be added to input and textarea form elements. The inputmode determines which keyboard is going to be displayed on mobile devices without a physical keyboard. The autocapitalize attribute tells mobile browsers how to capitalize the contents of the form field.