### PR TITLE
TASK: Update dynamic @cache example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ prototype(Some.Package:ContactForm) < prototype(Neos.Form.Builder:Form) {
         entryIdentifier {
             node = ${node}
         }
+        entryTags {
+            1 = ${Neos.Caching.nodeTag(node)}
+        }
         entryDiscriminator = ${request.httpRequest.methodSafe ? 'static' : false}
         context {
             1 = 'node'


### PR DESCRIPTION
I suggest to add the current node to the entry tags of the cache example. Otherwise, the dynamically cached form will be tagged with `Everything` which is flushed on every single registered node change (without respecting any context 🤯).