### PR TITLE
BUGFIX: Properly declare mixin node types as abstract

### DIFF
--- a/Configuration/NodeTypes.Mixin.DefaultValue.yaml
+++ b/Configuration/NodeTypes.Mixin.DefaultValue.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:DefaultValueMixin':
+  abstract: true
   properties:
     'defaultValue':
       type: string

--- a/Configuration/NodeTypes.Mixin.Identifier.yaml
+++ b/Configuration/NodeTypes.Mixin.Identifier.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:IdentifierMixin':
+  abstract: true
   properties:
     'identifier':
       type: string

--- a/Configuration/NodeTypes.Mixin.Label.yaml
+++ b/Configuration/NodeTypes.Mixin.Label.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:LabelMixin':
+  abstract: true
   properties:
     'label':
       type: string

--- a/Configuration/NodeTypes.Mixin.MaxLength.yaml
+++ b/Configuration/NodeTypes.Mixin.MaxLength.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:MaxlengthMixin':
+  abstract: true
   properties:
     'maxlength':
       type: integer

--- a/Configuration/NodeTypes.Mixin.Placeholder.yaml
+++ b/Configuration/NodeTypes.Mixin.Placeholder.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:PlaceholderMixin':
+  abstract: true
   properties:
     'placeholder':
       type: string

--- a/Configuration/NodeTypes.Mixin.RequiredCheckbox.yaml
+++ b/Configuration/NodeTypes.Mixin.RequiredCheckbox.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:RequiredCheckboxMixin':
+  abstract: true
   properties:
     'required':
       type: boolean

--- a/Configuration/NodeTypes.Mixin.Section.yaml
+++ b/Configuration/NodeTypes.Mixin.Section.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:SectionMixin':
+  abstract: true
   childNodes:
     'elements':
       type: 'Neos.Form.Builder:ElementCollection'

--- a/Configuration/NodeTypes.Mixin.Selection.yaml
+++ b/Configuration/NodeTypes.Mixin.Selection.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:SelectionMixin':
+  abstract: true
   ui:
     group: 'form.select'
   childNodes:

--- a/Configuration/NodeTypes.Mixin.TextValidators.yaml
+++ b/Configuration/NodeTypes.Mixin.TextValidators.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:TextValidatorsMixin':
+  abstract: true
   superTypes:
     'Neos.Form.Builder:ValidatorsMixin': true
   childNodes:

--- a/Configuration/NodeTypes.Mixin.Validators.yaml
+++ b/Configuration/NodeTypes.Mixin.Validators.yaml
@@ -1,4 +1,5 @@
 'Neos.Form.Builder:ValidatorsMixin':
+  abstract: true
   childNodes:
     'validators':
       type: 'Neos.Form.Builder:ValidatorCollection'


### PR DESCRIPTION
Adds a `abstract: true` to all mixin node type definitions such that they can't be assigned individually