### PR TITLE
Neos 9 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Project files
+/.idea/workspace.xml
+/.idea/tasks.xml
+/.idea/markdown-navigator*
+/.idea/shelf
+/dev/.vagrant/
+/dev/php_errors.log
+/dev/dev-control/
+/dev/db_backup_*
+/dev/local.itermocil.yaml
+
+
+# General swap/backup files
+*.so
+*.log
+*.out
+*~
+*.swp
+*.DS_Store
+*.sass-cache*
+
+!*.gitkeep

--- a/Classes/Fusion/Helper/NodeHelper.php
+++ b/Classes/Fusion/Helper/NodeHelper.php
@@ -1,7 +1,8 @@
 <?php
 namespace Neos\Form\Builder\Fusion\Helper;
 
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\PropertyCollection;
 use Neos\Eel\ProtectedContextAwareInterface;
 
 /**
@@ -13,16 +14,14 @@ class NodeHelper implements ProtectedContextAwareInterface
     /**
      * Merge properties of the specified $node to the given $properties (with precedence to node properties)
      *
-     * Note: This is required since NodeInterface::getProperties() does no longer return an array but an instance of PropertyCollectionInterface
-     *
      * @param array $properties
-     * @param NodeInterface $node
+     * @param Node $node
      * @return array
      */
-    public function mergeProperties(array $properties, NodeInterface $node): array
+    public function mergeProperties(array $properties, Node $node): array
     {
-        $nodeProperties = $node->getProperties();
-        if ($nodeProperties instanceof \Traversable) {
+        $nodeProperties = $node->properties;
+        if ($nodeProperties instanceof PropertyCollection) {
             $nodeProperties = iterator_to_array($nodeProperties);
         }
         return array_merge($properties, $nodeProperties);

--- a/Classes/Fusion/SelectOptionCollectionImplementation.php
+++ b/Classes/Fusion/SelectOptionCollectionImplementation.php
@@ -7,16 +7,21 @@ use Neos\Utility\ObjectAccess;
 class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
 {
 
-    protected $ignoreProperties = ['prependOptionLabel', 'prependOptionValue', 'labelPropertyPath', 'valuePropertyPath'];
+    protected $ignoreProperties = [
+        'prependOptionLabel',
+        'prependOptionValue',
+        'labelPropertyPath',
+        'valuePropertyPath'
+    ];
 
     public function evaluate()
     {
-        $collection = $this->getCollection();
+        $items = $this->getItems();
         $options = [];
         if (!empty($prependLabel = $this->getPrependOptionLabel())) {
             $options[$this->getPrependOptionValue()] = $prependLabel;
         }
-        if ($collection === null) {
+        if ($items === null) {
             foreach ($this->properties as $propertyName => $propertyValue) {
                 if (in_array($propertyName, $this->ignoreProperties)) {
                     continue;
@@ -24,7 +29,7 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
                 $options[$propertyName] = $propertyValue;
             }
         } else {
-            foreach ($collection as $item) {
+            foreach ($items as $item) {
                 $value = ObjectAccess::getPropertyPath($item, $this->getValuePropertyPath());
                 $label = ObjectAccess::getPropertyPath($item, $this->getLabelPropertyPath());
                 if (strlen($label) === 0) {
@@ -39,9 +44,9 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
     /**
      * @return array|\Traversable
      */
-    private function getCollection()
+    private function getItems()
     {
-        return $this->fusionValue('collection');
+        return $this->fusionValue('items');
     }
 
     private function getValuePropertyPath(): string

--- a/Classes/NodeType/FormNodeTypePostprocessor.php
+++ b/Classes/NodeType/FormNodeTypePostprocessor.php
@@ -1,8 +1,8 @@
 <?php
 namespace Neos\Form\Builder\NodeType;
 
-use Neos\ContentRepository\Domain\Model\NodeType;
-use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Core\NodeType\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\Flow\Annotations as Flow;
 
 class FormNodeTypePostprocessor implements NodeTypePostprocessorInterface

--- a/Classes/NodeType/ResourceCollectionsPostprocessor.php
+++ b/Classes/NodeType/ResourceCollectionsPostprocessor.php
@@ -1,8 +1,8 @@
 <?php
 namespace Neos\Form\Builder\NodeType;
 
-use Neos\ContentRepository\Domain\Model\NodeType;
-use Neos\ContentRepository\NodeTypePostprocessor\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Core\NodeType\NodeTypePostprocessorInterface;
+use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/NodeType/SelectOptionsCreationHandler.php
+++ b/Classes/NodeType/SelectOptionsCreationHandler.php
@@ -1,26 +1,32 @@
 <?php
 namespace Neos\Form\Builder\NodeType;
 
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
 
 class SelectOptionsCreationHandler implements NodeCreationHandlerInterface
 {
+
     /**
-     * @param NodeInterface $node The newly created node
-     * @param array $data incoming data from the creationDialog
-     * @return void
+     * @param CreateNodeAggregateWithNode $command The original node creation command
+     * @param array<string|int,mixed> $data incoming data from the creationDialog
+     * @return CreateNodeAggregateWithNode the original command or a new creation command with altered properties
      */
-    public function handle(NodeInterface $node, array $data)
+    public function handle(CreateNodeAggregateWithNode $command, array $data, ContentRepository $contentRepository): CreateNodeAggregateWithNode
     {
-        if (!$node->getNodeType()->isOfType('Neos.Form.Builder:SelectOption')) {
-            return;
+        if (!$contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)->isOfType('Neos.Form.Builder:SelectOption')) {
+            return $command;
         }
+
         if (isset($data['value'])) {
-            $node->setProperty('value', $data['value']);
+            $propertyValues = $propertyValues->withValue('value', $data['value']);
         }
         if (isset($data['label'])) {
-            $node->setProperty('label', $data['label']);
+            $propertyValues = $propertyValues->withValue('label', $data['label']);
         }
+
+        return $command->withInitialPropertyValues($propertyValues);
     }
 }

--- a/Configuration/NodeTypes.FormElement.yaml
+++ b/Configuration/NodeTypes.FormElement.yaml
@@ -9,7 +9,7 @@
   constraints:
     nodeTypes:
       '*': false
-  label: "${q(node).property('identifier') || q(node).property('label') || ((node.nodeType.label || node.nodeType.name) + ' (' + node.name + ')')}"
+  label: "${q(node).property('identifier') || q(node).property('label') || ((node.nodeType.label || node.nodeTypeName.value) + ' (' + node.name + ')')}"
   ui:
     inlineEditable: true
     label: 'Form Element'

--- a/Configuration/NodeTypes.FormPage.yaml
+++ b/Configuration/NodeTypes.FormPage.yaml
@@ -1,5 +1,5 @@
 'Neos.Form.Builder:FormPage':
-  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('label') || ((I18n.translate(node.nodeType.label) || node.nodeType.name) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' '))), 100, '...')}"
+  label: "${String.cropAtWord(String.trim(String.stripTags(String.pregReplace(q(node).property('title') || q(node).property('label') || ((I18n.translate(node.nodeType.label) || node.nodeTypeName.value) + (node.autoCreated ? ' (' + node.name + ')' : '')), '/<br\\W*?\\/?>|\\x{00a0}|[^[:print:]]|\\s+/u', ' '))), 100, '...')}"
   superTypes:
     'Neos.Neos:Content': true
   constraints:

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ selectable:
     // ...
     properties {
         options = Neos.Form.Builder:SelectOptionCollection {
-            collection = ${q(site).children('[instanceof Some.Package:NewsletterCategory]')}
+            items = ${q(site).children('[instanceof Some.Package:NewsletterCategory]')}
             # we use the node identifier as value, we could use "name" or "label" instead for example
             valuePropertyPath = 'identifier'
         }

--- a/Resources/Private/Fusion/Form.fusion
+++ b/Resources/Private/Fusion/Form.fusion
@@ -8,7 +8,7 @@ prototype(Neos.Form.Builder:Form) {
     renderingOptions = Neos.Fusion:DataStructure
     renderCallbacks = Neos.Fusion:DataStructure
     firstPage = Neos.Form.Builder:FormPage.Definition {
-        elements = Neos.Form.Builder:ElementCollection
+      elements = Neos.Form.Builder:ElementCollection
     }
     furtherPages = Neos.Form.Builder:PageCollection
     finishers = Neos.Form.Builder:FinisherCollection

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFinisher.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFinisher.fusion
@@ -11,7 +11,7 @@ prototype(Neos.Form.Builder:NodeBasedFinisherCollection) < prototype(Neos.Fusion
         formElementTypeFromNodeType {
             condition = ${!finisherNode.nodeType.options.form.formElementType}
             renderer = Neos.Form.Builder:NodeBasedFinisher {
-                type = ${finisherNode.nodeType.name + '.Definition'}
+                type = ${finisherNode.nodeTypeName.value + '.Definition'}
             }
         }
 

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFinisher.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFinisher.fusion
@@ -5,7 +5,7 @@ prototype(Neos.Form.Builder:NodeBasedFinisher) < prototype(Neos.Fusion:Renderer)
     }
 }
 
-prototype(Neos.Form.Builder:NodeBasedFinisherCollection) < prototype(Neos.Fusion:Collection) {
+prototype(Neos.Form.Builder:NodeBasedFinisherCollection) < prototype(Neos.Fusion:Loop) {
     itemName = 'finisherNode'
     itemRenderer = Neos.Fusion:Case {
         formElementTypeFromNodeType {

--- a/Resources/Private/Fusion/NodeBased/NodeBasedForm.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedForm.fusion
@@ -14,18 +14,18 @@ prototype(Neos.Form.Builder:NodeBasedForm) < prototype(Neos.Form.Builder:Form) {
         renderingOptions._node = ${formNode}
         renderingOptions._fusionPath = ${formFusionPath}
         elements = Neos.Form.Builder:NodeBasedElementCollection {
-            collection = ${q(formNode).children('elements').children()}
+            items = ${q(formNode).children('elements').children()}
         }
     }
     furtherPages = Neos.Form.Builder:NodeBasedPageCollection {
-        collection = ${q(formNode).children('furtherPages').children()}
+        items = ${q(formNode).children('furtherPages').children()}
     }
     finishers = Neos.Form.Builder:NodeBasedFinisherCollection {
-        collection = ${q(formNode).children('finishers').children()}
+        items = ${q(formNode).children('finishers').children()}
     }
     @process.contentElementWrapping = Neos.Neos:ContentElementWrapping {
         additionalAttributes {
-            'data-_neos-form-builder-type' = ${formNode.nodeType.name}
+            'data-_neos-form-builder-type' = ${formNode.nodeTypeName.value}
         }
     }
 

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
@@ -26,7 +26,7 @@ prototype(Neos.Form.Builder:NodeBasedFormElement) < prototype(Neos.Fusion:Render
     }
 }
 
-prototype(Neos.Form.Builder:NodeBasedElementCollection) < prototype(Neos.Fusion:Collection) {
+prototype(Neos.Form.Builder:NodeBasedElementCollection) < prototype(Neos.Fusion:Loop) {
     itemName = 'elementNode'
     itemRenderer = Neos.Fusion:Case {
         formElementTypeFromNodeType {

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormElement.fusion
@@ -7,20 +7,20 @@ prototype(Neos.Form.Builder:NodeBasedFormElement) < prototype(Neos.Fusion:Render
         defaultValue = ${elementNode.properties.defaultValue}
         properties.@process.addNodeProperties = ${Neos.Form.Builder.Node.mergeProperties(value, elementNode)}
         validators = Neos.Form.Builder:NodeBasedValidatorCollection {
-            collection = ${q(elementNode).children('validators').children()}
+            items = ${q(elementNode).children('validators').children()}
         }
         renderingOptions._node = ${elementNode}
         renderingOptions._fusionPath = ${element.path}
 
         properties.options.@process.overrideFromNode = Neos.Form.Builder:SelectOptionCollection {
-            collection = ${q(elementNode).children('options').children()}
+            items = ${q(elementNode).children('options').children()}
             valuePropertyPath = 'properties.value'
             labelPropertyPath = 'properties.label'
             @if.isSelectFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SelectionMixin]')}
         }
 
         elements.@process.overrideFromNode = Neos.Form.Builder:NodeBasedElementCollection {
-            collection = ${q(elementNode).children('elements').children()}
+            items = ${q(elementNode).children('elements').children()}
             @if.isSectionFormElement = ${q(elementNode).is('[instanceof Neos.Form.Builder:SectionMixin]')}
         }
     }
@@ -32,7 +32,7 @@ prototype(Neos.Form.Builder:NodeBasedElementCollection) < prototype(Neos.Fusion:
         formElementTypeFromNodeType {
             condition = ${!elementNode.nodeType.options.form.formElementType}
             renderer = Neos.Form.Builder:NodeBasedFormElement {
-                type = ${elementNode.nodeType.name + '.Definition'}
+                type = ${elementNode.nodeTypeName.value + '.Definition'}
             }
         }
         default {

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormPage.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormPage.fusion
@@ -7,7 +7,7 @@ prototype(Neos.Form.Builder:NodeBasedFormPage) < prototype(Neos.Fusion:Renderer)
         renderingOptions._fusionPath = ${page.path}
 
         elements = Neos.Form.Builder:NodeBasedElementCollection {
-            collection = ${q(pageNode).children('elements').children()}
+            items = ${q(pageNode).children('elements').children()}
         }
     }
 }
@@ -18,7 +18,7 @@ prototype(Neos.Form.Builder:NodeBasedPageCollection) < prototype(Neos.Fusion:Loo
         formElementTypeFromNodeType {
             condition = ${!pageNode.nodeType.options.form.formElementType}
             renderer = Neos.Form.Builder:NodeBasedFormPage {
-                type = ${pageNode.nodeType.name + '.Definition'}
+                type = ${pageNode.nodeTypeName.value + '.Definition'}
             }
         }
 

--- a/Resources/Private/Fusion/NodeBased/NodeBasedFormPage.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedFormPage.fusion
@@ -12,7 +12,7 @@ prototype(Neos.Form.Builder:NodeBasedFormPage) < prototype(Neos.Fusion:Renderer)
     }
 }
 
-prototype(Neos.Form.Builder:NodeBasedPageCollection) < prototype(Neos.Fusion:Collection) {
+prototype(Neos.Form.Builder:NodeBasedPageCollection) < prototype(Neos.Fusion:Loop) {
     itemName = 'pageNode'
     itemRenderer = Neos.Fusion:Case {
         formElementTypeFromNodeType {

--- a/Resources/Private/Fusion/NodeBased/NodeBasedValidator.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedValidator.fusion
@@ -11,7 +11,7 @@ prototype(Neos.Form.Builder:NodeBasedValidatorCollection) < prototype(Neos.Fusio
         formElementTypeFromNodeType {
             condition = ${!validatorNode.nodeType.options.form.formElementType}
             renderer = Neos.Form.Builder:NodeBasedValidator {
-                type = ${validatorNode.nodeType.name + '.Definition'}
+                type = ${validatorNode.nodeTypeName.value + '.Definition'}
             }
         }
 

--- a/Resources/Private/Fusion/NodeBased/NodeBasedValidator.fusion
+++ b/Resources/Private/Fusion/NodeBased/NodeBasedValidator.fusion
@@ -5,7 +5,7 @@ prototype(Neos.Form.Builder:NodeBasedValidator) < prototype(Neos.Fusion:Renderer
     }
 }
 
-prototype(Neos.Form.Builder:NodeBasedValidatorCollection) < prototype(Neos.Fusion:Collection) {
+prototype(Neos.Form.Builder:NodeBasedValidatorCollection) < prototype(Neos.Fusion:Loop) {
     itemName = 'validatorNode'
     itemRenderer = Neos.Fusion:Case {
         formElementTypeFromNodeType {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Flow Form Framework integration into Neos CMS",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "^5.0 || ^7.0 || ^8.0",
+        "neos/neos": "^5.0 || ^7.0 || ^8.0 || ^9.0",
         "neos/form": "^5.0"
     },
     "autoload": {


### PR DESCRIPTION
Adding Neos 9 compatibilty.

- Using new content repository in FormProcessors
- Fixing deprecated fusion prototypes.
- !Breaking Removed setting of uniqueFormIdentifier in `Classes/Package.php`, because there are no `Node` signal slots anymore. How would we go about that in the future? Do we need to use an Anspect now?