### PR TITLE
BUGFIX: Allow `furtherPages` child node to be removed

### DIFF
--- a/Classes/Fusion/FormElementWrappingImplementation.php
+++ b/Classes/Fusion/FormElementWrappingImplementation.php
@@ -59,7 +59,10 @@ class FormElementWrappingImplementation extends AbstractFusionObject
                         $output = $this->wrapNodeRecursively($finishersNode, '', $fusionPath . '/finishers') . $output;
                     }
                     if (!$renderable->getRootForm()->hasPageWithIndex(1)) {
-                        $output = $output . $this->wrapNode($node->getNode('furtherPages'), '', $fusionPath . '/furtherPages');
+                        $furtherPagesNode = $node->getNode('furtherPages');
+                        if ($furtherPagesNode !== null) {
+                            $output = $output . $this->wrapNode($furtherPagesNode, '', $fusionPath . '/furtherPages');
+                        }
                     }
                     return $output;
                 }


### PR DESCRIPTION
Adds a safe guard that allows the `firtherPages` node to be disabled if it's not needed:

```yaml
  childNodes:
    'furtherPages': ~
```

Fixes: #135