### PR TITLE
Add `deleteAfterLastPage` Property to FileUpload Form Element for Improved Security

### DIFF
--- a/Configuration/NodeTypes.FormElements.FileUpload.yaml
+++ b/Configuration/NodeTypes.FormElements.FileUpload.yaml
@@ -52,3 +52,9 @@
         inspector:
           group: 'formElement'
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+    'deleteAfterLastPage':
+      type: boolean
+      ui:
+        label: i18n
+        inspector:
+          group: 'formElement'

--- a/Resources/Private/Fusion/Elements/FileUpload.fusion
+++ b/Resources/Private/Fusion/Elements/FileUpload.fusion
@@ -3,5 +3,6 @@ prototype(Neos.Form.Builder:FileUpload.Definition) < prototype(Neos.Form.Builder
 
     properties {
         allowedExtensions = Neos.Fusion:DataStructure
+        deleteAfterLastPage = ${false}
     }
 }

--- a/Resources/Private/Translations/da/NodeTypes/FileUpload.xlf
+++ b/Resources/Private/Translations/da/NodeTypes/FileUpload.xlf
@@ -6,6 +6,10 @@
 				<source>Allowed file types</source>
 				<target>Tilladte filtyper</target>
 			</trans-unit>
+			<trans-unit id="properties.deleteAfterLastPage" xml:space="preserve">
+				<source>Delete after last page</source>
+				<target>Slet efter sidste side</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/FileUpload.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/FileUpload.xlf
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <trans-unit id="properties.allowedExtensions" xml:space="preserve">
-				<source>Allowed file types</source>
-			<target xml:lang="de" state="translated">Erlaubte Dateitypen</target></trans-unit>
-      <trans-unit id="properties.resourceCollection" xml:space="preserve">
-				<source>Target Resource Collection</source>
-			<target xml:lang="de" state="translated">Ziel "Resource Collection"</target></trans-unit>
-    </body>
-  </file>
+    <file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext" target-language="de">
+        <body>
+            <trans-unit id="properties.allowedExtensions" xml:space="preserve">
+                <source>Allowed file types</source>
+                <target xml:lang="de" state="translated">Erlaubte Dateitypen</target>
+            </trans-unit>
+            <trans-unit id="properties.resourceCollection" xml:space="preserve">
+                <source>Target Resource Collection</source>
+                <target xml:lang="de" state="translated">Ziel "Resource Collection"</target>
+            </trans-unit>
+            <trans-unit id="properties.deleteAfterLastPage" xml:space="preserve">
+                <source>Delete after last page</source>
+                <target>Nach letzter Seite löschen</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/FileUpload.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/FileUpload.xlf
@@ -8,6 +8,9 @@
 			<trans-unit id="properties.resourceCollection" xml:space="preserve">
 				<source>Target Resource Collection</source>
 			</trans-unit>
+			<trans-unit id="properties.deleteAfterLastPage" xml:space="preserve">
+				<source>Delete after last page</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
### Context and Problem

- **Vulnerability**: At present, every file uploaded through our forms is stored in the resources directory, regardless of its necessity after form submission. This persistent storage is a security risk, particularly exposing the system to spider attacks, where malicious users or bots can flood the system with unnecessary uploads, leading to potential misuse or resource exhaustion.

### Proposed Solution

- **Conditional File Retention**: This pull request, together with the pull request in `neos/form` and in `neos/form-fusionrenderer`, introduces a mechanism to evaluate whether an uploaded file should be retained or deleted after the final form submission. By doing so, it allows the finisher process to handle the file temporarily without storing it permanently unless explicitly needed.

### Benefits

- **Security Improvement**: Reduces the attack surface by preventing unnecessary file storage.
- **Resource Management**: Frees up resources by ensuring only necessary files are stored, thus optimizing storage utilization.
- **Cleaner Implementation**: Provides a cleaner and more efficient way to handle temporary uploads, aligning with best practices in file management and security.

### Changes Introduced in this pull request

- **File Handling Logic**: Added conditional checks to determine if the uploaded file should be retained or deleted post form submission.
- **Configuration Options**: Introduced configuration settings to allow customization of file retention policies.
- Further changes are introduced in the pull request in `neos/form` and in `neos/form-fusionrenderer`

### Implementation Details

- **Functionality**: The implementation involves adding a flag in file upload form element property that indicates whether an uploaded file should be kept or deleted. This flag is checked during the form submission after the last page of this form.
- Further implementation details are in `neos/form` and in `neos/form-fusionrenderer`