### PR TITLE
Add Validator for FileUpload

### DIFF
--- a/Configuration/NodeTypes.FormElements.FileUpload.yaml
+++ b/Configuration/NodeTypes.FormElements.FileUpload.yaml
@@ -15,37 +15,6 @@
         'formElement':
           icon: 'icon-upload'
   properties:
-    'allowedExtensions':
-      type: array
-      ui:
-        label: i18n
-        reloadIfChanged: true
-        inspector:
-          group: 'formElement'
-          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
-          editorOptions:
-            values:
-              'pdf':
-                label: '.pdf'
-                icon: 'icon-file-pdf-o'
-              'xls':
-                label: '.xls'
-                icon: 'icon-file-excel-o'
-              'xlsx':
-                label: '.xlsx'
-                icon: 'icon-file-excel-o'
-              'doc':
-                label: '.doc'
-                icon: 'icon-file-text'
-              'docx':
-                label: '.docx'
-                icon: 'icon-file-text'
-              'odt':
-                label: '.odt'
-                icon: 'icon-file-text'
-              'csv':
-                label: '.csv'
-                icon: 'icon-file-text'
     'resourceCollection':
       type: string
       ui:

--- a/Configuration/NodeTypes.Mixin.File.yaml
+++ b/Configuration/NodeTypes.Mixin.File.yaml
@@ -1,0 +1,10 @@
+'Neos.Form.Builder:FileMixin':
+  abstract: true
+  superTypes:
+    'Neos.Form.Builder:ValidatorsMixin': true
+  childNodes:
+    'validators':
+      constraints:
+        nodeTypes:
+          'Neos.Form.Builder:FileSizeValidator': true
+          'Neos.Form.Builder:FileTypeValidator': true

--- a/Configuration/NodeTypes.Mixin.FileValidators.yaml
+++ b/Configuration/NodeTypes.Mixin.FileValidators.yaml
@@ -1,0 +1,10 @@
+'Neos.Form.Builder:FileValidatorsMixin':
+  abstract: true
+  superTypes:
+    'Neos.Form.Builder:ValidatorsMixin': true
+  childNodes:
+    'validators':
+      constraints:
+        nodeTypes:
+          'Neos.Form.Builder:FileSizeValidator': true
+          'Neos.Form.Builder:FileExtensionValidator': true

--- a/Configuration/NodeTypes.Validator.FileExtension.yaml
+++ b/Configuration/NodeTypes.Validator.FileExtension.yaml
@@ -2,8 +2,8 @@
   superTypes:
     'Neos.Form.Builder:AbstractValidator': true
   ui:
-    label: 'File Type Validator'
-    icon: 'icon-sort-numeric-asc'
+    label: 'File Extension Validator'
+    icon: 'file-archive'
     inspector:
       groups:
         'validator':

--- a/Configuration/NodeTypes.Validator.FileExtension.yaml
+++ b/Configuration/NodeTypes.Validator.FileExtension.yaml
@@ -1,19 +1,13 @@
-'Neos.Form.Builder:FileUpload':
+'Neos.Form.Builder:FileExtensionValidator':
   superTypes:
-    'Neos.Form.Builder:FormElement': true
-    'Neos.Form.Builder:DefaultValueMixin': false
-    'Neos.Form.Builder:FileValidatorsMixin': true
-  postprocessors:
-    'Neos.Form.Builder:ResourceCollectionsPostprocessor':
-      postprocessor: 'Neos\Form\Builder\NodeType\ResourceCollectionsPostprocessor'
+    'Neos.Form.Builder:AbstractValidator': true
   ui:
-    label: 'File upload'
-    icon: 'icon-upload'
-    group: 'form.custom'
+    label: 'File Type Validator'
+    icon: 'icon-sort-numeric-asc'
     inspector:
       groups:
-        'formElement':
-          icon: 'icon-upload'
+        'validator':
+          icon: 'icon-sort-numeric-asc'
   properties:
     'allowedExtensions':
       type: array
@@ -21,7 +15,7 @@
         label: i18n
         reloadIfChanged: true
         inspector:
-          group: 'formElement'
+          group: 'validator'
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             values:
@@ -46,10 +40,6 @@
               'csv':
                 label: '.csv'
                 icon: 'icon-file-text'
-    'resourceCollection':
-      type: string
-      ui:
-        label: i18n
-        inspector:
-          group: 'formElement'
-          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+              'zip':
+                label: '.zip'
+                icon: 'icon-file-text'

--- a/Configuration/NodeTypes.Validator.FileExtension.yaml
+++ b/Configuration/NodeTypes.Validator.FileExtension.yaml
@@ -3,11 +3,11 @@
     'Neos.Form.Builder:AbstractValidator': true
   ui:
     label: 'File Extension Validator'
-    icon: 'file-archive'
+    icon: 'icon-file-archive'
     inspector:
       groups:
         'validator':
-          icon: 'icon-sort-numeric-asc'
+          icon: 'icon-filter'
   properties:
     'allowedExtensions':
       type: array

--- a/Configuration/NodeTypes.Validator.FileExtension.yaml
+++ b/Configuration/NodeTypes.Validator.FileExtension.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Form.Builder:AbstractValidator': true
   ui:
-    label: 'File Extension Validator'
+    label: 'File-Extension Validator'
     icon: 'icon-file-archive'
     inspector:
       groups:

--- a/Configuration/NodeTypes.Validator.FileSize.yaml
+++ b/Configuration/NodeTypes.Validator.FileSize.yaml
@@ -1,0 +1,25 @@
+'Neos.Form.Builder:FileSizeValidator':
+  superTypes:
+    'Neos.Form.Builder:AbstractValidator': true
+  ui:
+    label: 'File size range Validator'
+    icon: 'icon-sort-numeric-asc'
+    inspector:
+      groups:
+        'validator':
+          icon: 'icon-sort-numeric-asc'
+  properties:
+    'minimum':
+      type: integer
+      defaultValue: 0
+      ui:
+        label: i18n
+        inspector:
+          group: 'validator'
+    'maximum':
+      type: integer
+      defaultValue: 100
+      ui:
+        label: i18n
+        inspector:
+          group: 'validator'

--- a/Configuration/NodeTypes.Validator.FileSize.yaml
+++ b/Configuration/NodeTypes.Validator.FileSize.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Form.Builder:AbstractValidator': true
   ui:
-    label: 'File size range Validator'
+    label: 'File-Size range Validator'
     icon: 'icon-arrows-alt-h'
     inspector:
       groups:

--- a/Configuration/NodeTypes.Validator.FileSize.yaml
+++ b/Configuration/NodeTypes.Validator.FileSize.yaml
@@ -3,11 +3,11 @@
     'Neos.Form.Builder:AbstractValidator': true
   ui:
     label: 'File size range Validator'
-    icon: 'icon-sort-numeric-asc'
+    icon: 'icon-arrows-alt-h'
     inspector:
       groups:
         'validator':
-          icon: 'icon-sort-numeric-asc'
+          icon: 'icon-filter'
   properties:
     'minimum':
       type: integer

--- a/Resources/Private/Fusion/Validators/FileExtensionValidator.fusion
+++ b/Resources/Private/Fusion/Validators/FileExtensionValidator.fusion
@@ -2,6 +2,15 @@
 prototype(Neos.Form.Builder:FileExtensionValidator.Definition) < prototype(Neos.Form.Builder:Validator.Definition) {
     formElementType = 'Neos.Flow:FileExtension'
     options {
-      allowedExtensions = Neos.Fusion:DataStructure
+      allowedExtensions = Neos.Fusion:DataStructure {
+        pdf = 'pdf'
+        xls = 'xls'
+        xlsx = 'xlsx'
+        doc = 'doc'
+        docx = 'docx'
+        odt = 'odt'
+        csv = 'csv'
+        zip = 'zip'
+      }
     }
 }

--- a/Resources/Private/Fusion/Validators/FileExtensionValidator.fusion
+++ b/Resources/Private/Fusion/Validators/FileExtensionValidator.fusion
@@ -1,0 +1,7 @@
+# See Neos\Flow\Validation\Validator\FileTypeValidator
+prototype(Neos.Form.Builder:FileExtensionValidator.Definition) < prototype(Neos.Form.Builder:Validator.Definition) {
+    formElementType = 'Neos.Flow:FileExtension'
+    options {
+      allowedExtensions = Neos.Fusion:DataStructure
+    }
+}

--- a/Resources/Private/Fusion/Validators/FileSizeValidator.fusion
+++ b/Resources/Private/Fusion/Validators/FileSizeValidator.fusion
@@ -1,0 +1,8 @@
+# See Neos\Flow\Validation\Validator\FileSizeValidator
+prototype(Neos.Form.Builder:FileSizeValidator.Definition) < prototype(Neos.Form.Builder:Validator.Definition) {
+    formElementType = 'Neos.Flow:FileSize'
+    options {
+        minimum = 0
+        maximum = 10000000
+    }
+}

--- a/Resources/Private/Translations/da/NodeTypes/FileExtensionValidator.xlf
+++ b/Resources/Private/Translations/da/NodeTypes/FileExtensionValidator.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" target-language="da" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.allowedExtensions" xml:space="preserve">
+				<source>Allowed file types</source>
+				<target>Tilladte filtyper</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/da/NodeTypes/FileSizeValidator.xlf
+++ b/Resources/Private/Translations/da/NodeTypes/FileSizeValidator.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" target-language="da" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.minimum" xml:space="preserve">
+				<source>Minimum value</source>
+				<target>Mindste værdi i bytes</target>
+			</trans-unit>
+			<trans-unit id="properties.maximum" xml:space="preserve">
+				<source>Maximum value</source>
+				<target>Højeste værdi i bytes</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/de/NodeTypes/FileExtensionValidator.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/FileExtensionValidator.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="properties.allowedExtensions" xml:space="preserve">
+				<source>Allowed file types</source>
+			<target xml:lang="de" state="translated">Erlaubte Dateitypen</target></trans-unit>
+      <trans-unit id="properties.resourceCollection" xml:space="preserve">
+				<source>Target Resource Collection</source>
+			<target xml:lang="de" state="translated">Ziel "Resource Collection"</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/de/NodeTypes/FileSizeValidator.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/FileSizeValidator.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+      <trans-unit id="properties.minimum" xml:space="preserve">
+				<source>Minimum value</source>
+			<target xml:lang="de" state="translated">Mindestwert in Bytes</target></trans-unit>
+      <trans-unit id="properties.maximum" xml:space="preserve">
+				<source>Maximum value</source>
+			<target xml:lang="de" state="translated">Maximalwert in Bytes</target></trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/FileExtensionValidator.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/FileExtensionValidator.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.allowedExtensions" xml:space="preserve">
+				<source>Allowed file types</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/FileSizeValidator.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/FileSizeValidator.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Form.Builder" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.minimum" xml:space="preserve">
+				<source>Minimum value in bytes</source>
+			</trans-unit>
+			<trans-unit id="properties.maximum" xml:space="preserve">
+				<source>Maximum value in bytes</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
In this PR the FileUpload FormElement getting a validators

`form-builder/Configuration/NodeTypes.FormElements.FileUpload.yaml`
```yaml
    'allowedExtensions':
      type: array
      ui:
        label: i18n
        reloadIfChanged: true
        inspector:
          group: 'formElement'
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            values:
              'pdf':
                label: '.pdf'
                icon: 'icon-file-pdf-o'
              'xls':
                label: '.xls'
                icon: 'icon-file-excel-o'
              'xlsx':
                label: '.xlsx'
                icon: 'icon-file-excel-o'
              'doc':
                label: '.doc'
                icon: 'icon-file-text'
              'docx':
                label: '.docx'
                icon: 'icon-file-text'
              'odt':
                label: '.odt'
                icon: 'icon-file-text'
              'csv':
                label: '.csv'
                icon: 'icon-file-text'
```

The code above is removed from `FileUpload` and become an validator
`Configuration/NodeTypes.Validator.FileExtension.yaml`
```yaml
'Neos.Form.Builder:FileExtensionValidator':
  superTypes:
    'Neos.Form.Builder:AbstractValidator': true
  ui:
    label: 'File-Extension Validator'
    icon: 'icon-file-archive'
    inspector:
      groups:
        'validator':
          icon: 'icon-filter'
  properties:
    'allowedExtensions':
      type: array
      ui:
        label: i18n
        reloadIfChanged: true
        inspector:
          group: 'validator'
          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
          editorOptions:
            values:
              'pdf':
                label: '.pdf'
                icon: 'icon-file-pdf-o'
              'xls':
                label: '.xls'
                icon: 'icon-file-excel-o'
              'xlsx':
                label: '.xlsx'
                icon: 'icon-file-excel-o'
              'doc':
                label: '.doc'
                icon: 'icon-file-text'
              'docx':
                label: '.docx'
                icon: 'icon-file-text'
              'odt':
                label: '.odt'
                icon: 'icon-file-text'
              'csv':
                label: '.csv'
                icon: 'icon-file-text'
              'zip':
                label: '.zip'
                icon: 'icon-file-text'
```

Another Validator is the `FileSizeValidator`
```yaml
'Neos.Form.Builder:FileSizeValidator':
  superTypes:
    'Neos.Form.Builder:AbstractValidator': true
  ui:
    label: 'File-Size range Validator'
    icon: 'icon-arrows-alt-h'
    inspector:
      groups:
        'validator':
          icon: 'icon-sort-numeric-asc'
  properties:
    'minimum':
      type: integer
      defaultValue: 0
      ui:
        label: i18n
        inspector:
          group: 'validator'
    'maximum':
      type: integer
      defaultValue: 100
      ui:
        label: i18n
        inspector:
          group: 'validator'

```

A Mixin: `FileValidatorsMixin`
```yaml
'Neos.Form.Builder:FileValidatorsMixin':
  abstract: true
  superTypes:
    'Neos.Form.Builder:ValidatorsMixin': true
  childNodes:
    'validators':
      constraints:
        nodeTypes:
          'Neos.Form.Builder:FileSizeValidator': true
          'Neos.Form.Builder:FileExtensionValidator': true
```

Now inside of NEOS it looks like this: 
![image](https://github.com/user-attachments/assets/8f7d36f8-440b-4990-b98f-0a49215a62e8)

# Important: 
Dependencies with another Package!
`Neos:Form`
`Neos.Form/Configuration/Settings.yaml`

It is needed to add the following: 
```yaml
          'Neos.Flow:FileSize':
            implementationClassName: Neos\Flow\Validation\Validator\FileSizeValidator
          'Neos.Flow:FileExtension':
            implementationClassName: Neos\Flow\Validation\Validator\FileExtensionValidator
```
to: 
```yaml
Neos:
  Form:
    presets:
      default:
        validatorPresets:
```
`Neos:Form`
`Neos.Form/Classes/FormElements/FileUpload.php`
Remove old FileExtensionValidation Code
```php
        $fileTypeValidator = new FileTypeValidator(array('allowedExtensions' => $this->properties['allowedExtensions']));
        $this->addValidator($fileTypeValidator);
```
This can be removed. 
# Problem: 
We need a migration: 
for smooth use. 
I'm not good with migrations. 
