### PR TITLE
FEATURE: Use Fusion rendering to collect option values and labels for dynamic options

### DIFF
--- a/Classes/Fusion/SelectOptionCollectionImplementation.php
+++ b/Classes/Fusion/SelectOptionCollectionImplementation.php
@@ -49,15 +49,12 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
         return $options;
     }
 
-    /**
-     * @return array|\Traversable
-     */
-    private function getItems()
+    private function getItems(): ?iterable
     {
         return $this->fusionValue('items');
     }
 
-    private function getItemName()
+    private function getItemName(): string
     {
         return $this->fusionValue('itemName');
     }

--- a/Classes/Fusion/SelectOptionCollectionImplementation.php
+++ b/Classes/Fusion/SelectOptionCollectionImplementation.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Neos\Form\Builder\Fusion;
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Fusion\FusionObjects\AbstractArrayFusionObject;
-use Neos\Utility\ObjectAccess;
 
 class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
 {
@@ -10,8 +11,9 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
     protected $ignoreProperties = [
         'prependOptionLabel',
         'prependOptionValue',
-        'labelPropertyPath',
-        'valuePropertyPath'
+        'items',
+        'itemName',
+        'itemRenderer'
     ];
 
     public function evaluate()
@@ -29,13 +31,19 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
                 $options[$propertyName] = $propertyValue;
             }
         } else {
-            foreach ($items as $item) {
-                $value = ObjectAccess::getPropertyPath($item, $this->getValuePropertyPath());
-                $label = ObjectAccess::getPropertyPath($item, $this->getLabelPropertyPath());
+            $renderedItems = $this->renderItems($items);
+            foreach ($renderedItems as $renderedItem) {
+                $value = $renderedItem['value'] ?? null;
+                $label = $renderedItem['label'] ?? null;
+
+                if ($value === null) {
+                    continue;
+                }
+
                 if (strlen($label) === 0) {
                     $label = $value;
                 }
-                $options[$value] = $label;
+                $options[(string)$value] = $label;
             }
         }
         return $options;
@@ -49,14 +57,9 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
         return $this->fusionValue('items');
     }
 
-    private function getValuePropertyPath(): string
+    private function getItemName()
     {
-        return $this->fusionValue('valuePropertyPath');
-    }
-
-    private function getLabelPropertyPath(): string
-    {
-        return $this->fusionValue('labelPropertyPath');
+        return $this->fusionValue('itemName');
     }
 
     private function getPrependOptionLabel(): string
@@ -67,5 +70,26 @@ class SelectOptionCollectionImplementation extends AbstractArrayFusionObject
     private function getPrependOptionValue(): string
     {
         return $this->fusionValue('prependOptionValue') ?? '';
+    }
+
+    private function renderItems(iterable $items): array
+    {
+        $itemName = $this->getItemName();
+        $itemRenderPath = $this->path . '/itemRenderer';
+
+        $result = [];
+        if ($this->runtime->canRender($itemRenderPath) === true) {
+            foreach ($items as $item) {
+                $context = $this->runtime->getCurrentContext();
+                $context[$itemName] = $item;
+
+                $this->runtime->pushContextArray($context);
+
+                $result[] = $this->runtime->render($itemRenderPath);
+
+                $this->runtime->popContext();
+            }
+        }
+        return $result;
     }
 }

--- a/README.md
+++ b/README.md
@@ -376,8 +376,17 @@ selectable:
     properties {
         options = Neos.Form.Builder:SelectOptionCollection {
             items = ${q(site).children('[instanceof Some.Package:NewsletterCategory]')}
-            # we use the node identifier as value, we could use "name" or "label" instead for example
-            valuePropertyPath = 'identifier'
+            itemRenderer = Neos.Fusion:DataStructure {
+                value = ${item.aggregateId}
+                label = ${q(item).property('title')}
+            }
         }
     }
 ```
+
+## Upgrade from to version 5
+### Neos.Form.Builder:SelectOptionCollection
+The `Neos.Form.Builder:SelectOptionCollection` prototype has been changed and uses now `items` instead of `collection`.
+
+Also, the way how dynamic options got collected has been changed. Instead of defining the property path, you now need to 
+use a renderer to render the `value` and `label` of your option. 

--- a/Resources/Private/Fusion/SelectOptionCollection.fusion
+++ b/Resources/Private/Fusion/SelectOptionCollection.fusion
@@ -3,6 +3,11 @@ prototype(Neos.Form.Builder:SelectOptionCollection) {
 
     prependOptionLabel = ${null}
     prependOptionValue = ${null}
-    valuePropertyPath = 'value'
-    labelPropertyPath = 'label'
+
+    items = null
+    itemName = 'item'
+    itemRenderer = Neos.Fusion:DataStructure {
+        value = null
+        label = null
+    }
 }


### PR DESCRIPTION
Instead accessing the node object properties directly, you now are able to define a renderer per item to build dynamic options.

Neos 9.0