### PR TITLE
Render options correctly

### DIFF
--- a/Resources/Private/Fusion/SelectOptionCollection.fusion
+++ b/Resources/Private/Fusion/SelectOptionCollection.fusion
@@ -7,7 +7,7 @@ prototype(Neos.Form.Builder:SelectOptionCollection) {
     items = null
     itemName = 'item'
     itemRenderer = Neos.Fusion:DataStructure {
-        value = null
-        label = null
+        value = ${q(item).property("value")}
+        label = ${q(item).property("label")}
     }
 }


### PR DESCRIPTION
I debugged a little bit, why options are not rendered currently (as mentioned in #150). It seems that the `Neos.Form.Builder:SelectOptionCollection/itemRenderer` didn't fetched the properties, it just returns null which is stripped out by the implementation. 

fixes #150 