### PR TITLE
BUGFIX: Consider identifier unique if parent form has not been found

### DIFF
--- a/Classes/CommandHook/UniqueIdentifierCommandHook.php
+++ b/Classes/CommandHook/UniqueIdentifierCommandHook.php
@@ -92,6 +92,10 @@ class UniqueIdentifierCommandHook implements CommandHookInterface
             )
         );
 
+        if ($form === null) {
+            return $identifier;
+        }
+
         $uniqueIdentifier = null;
         $possibleIdentifier = $identifier;
         $i = 1;
@@ -107,7 +111,7 @@ class UniqueIdentifierCommandHook implements CommandHookInterface
             );
 
             if ($descendants->count() === 0
-                || $descendants->count() === 1 && $descendants->first()->aggregateId->equals($currentNodeAggregateId)) {
+                || ($descendants->count() === 1 && $descendants->first()->aggregateId->equals($currentNodeAggregateId))) {
                 $uniqueIdentifier = $possibleIdentifier;
             } else {
                 $possibleIdentifier = $identifier . '-' . $i++;


### PR DESCRIPTION
Thanks to @dhuettner for finding the root cause.

We now check if the a form is present as ancestor. If not we consider the identifier as unique. 

Fixes: https://github.com/neos/form-builder/issues/154